### PR TITLE
Adds statement to directly create the EU election 2024 entity

### DIFF
--- a/database/migrations/2025_01_09_144535_create_elections_table.php
+++ b/database/migrations/2025_01_09_144535_create_elections_table.php
@@ -1,7 +1,9 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -21,6 +23,14 @@ return new class extends Migration
 
             $table->foreignId('country_id')->nullable()->constrained()->onUpdate('CASCADE')->onDelete('RESTRICT');
         });
+
+        DB::table('elections')->insert([
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+            'published' => true,
+            'date' => Carbon::createFromDate(2024, 6, 6),
+            'name' => 'European elections 2024',
+        ]);
     }
 
     /**


### PR DESCRIPTION
Note: Normally, migrations SHOULD NO be updated retroactively. In this case we know that the changes have not yet been deployed and not creating it together with the table might lead to other problems down the road. This is an exception.